### PR TITLE
Tar file is not gziped

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a Docker Swarm bundle that also includes logging and monitoring. It is c
 Any of the services provided can be scaled out post-deployment. The charms support workload status, so it is recommended to run `watch juju status` to monitor the cluster coming up. After it is deployed you need to grab the credentials from the lead swarm node to control the cluster:
 
     juju scp swarm/0:swarm_credentials.tar .
-    tar zxf swarm_credentials.tar
+    tar xvf swarm_credentials.tar
     cd swarm_credentials
     source enable.sh
 


### PR DESCRIPTION
Instructions state to pass as "z" option to untar the file but it is not gziped. This patch only untar.

tar zxf swarm_credentials.tar

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
$ tar xvf swarm_credentials.tar
swarm_credentials/
swarm_credentials/key.pem
swarm_credentials/enable.sh
swarm_credentials/ca.pem
swarm_credentials/cert.pem
$ file swarm_credentials.tar 
swarm_credentials.tar: POSIX tar archive (GNU)
arosales@x230:~/devel/containers$
